### PR TITLE
Updated to Swift 5.1 and Xcode 11

### DIFF
--- a/BLAS.playground/contents.swift
+++ b/BLAS.playground/contents.swift
@@ -9,8 +9,8 @@ import Accelerate
 Here we will find **10 * x + y** for a 3 element array.
 - Note: It's useful to add a comment above the code illustrating what you think the function is doing, because it's easy to grab the wrong function and very hard to figure out what you meant without such notes. Often there's enough room to align the math right over the variables.
 */
-var x:[Float] = [ 1, 2, 3 ]
-var y:[Float] = [ 3, 4, 5 ]
+var x: [Float] = [1, 2, 3]
+var y: [Float] = [3, 4, 5]
 
 //              10 * x    + y
 
@@ -27,14 +27,14 @@ y = [ 3, 4, 5 ]
 cblas_sdot( 3, &x, 1, &y, 1 )   // == 1*3 + 2*4 + 3*5
 //: ----
 //:## Scale a vector by some value
-var z:[Float] = [1,2,3,4,5,6]
+var z: [Float] = [1, 2, 3, 4, 5, 6]
 
 //              10 * z
 
-cblas_sscal( 6, 10, &z, 1 )
+cblas_sscal(6, 10, &z, 1)
 z
 
 //              100 * z  for every other element
 
-cblas_sscal( 6, 100, &z, 2 )
-z
+cblas_sscal(6, 100, &z, 2)
+//z

--- a/BLAS.playground/contents.xcplayground
+++ b/BLAS.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='osx' display-mode='raw' executeOnSourceChanges='false'>
+<playground version='5.0' target-platform='osx' display-mode='raw'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/BLAS.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/BLAS.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ComplexBLAS.playground/contents.swift
+++ b/ComplexBLAS.playground/contents.swift
@@ -8,20 +8,20 @@ import Accelerate
 - Note: Complex numbers are differently in different Accelerate libraries. Here, using the BLAS functions, they are represented by two floats in succession in an array. The first is the real component, the next the complex component. So each complex number is found every 2 elements in the array.
 - Note: When you get the result out, you are responsible for remembering that the array of floats you're left with are the complex valued results. Below the result is the array **[2,0,0,8]**, but this is code for **2 + 0i** and **0 + 8i**.
 */
-var z:[Float] = [ -3,  4,  5, -7  ]  // -3 + 4i, 5 - 7i
+var z: [Float] = [-3, 4, 5, -7]  // -3 + 4i, 5 - 7i
 
 // Ex 1: Sum of absolute value of components
 
-cblas_scasum( 2, &z, 1 )             // |-3| + |4| + |5| + |-7|  =  19
+cblas_scasum(2, &z, 1)             // |-3| + |4| + |5| + |-7|  =  19
 
 
-var a:[Float] = [ 1,  2,  3, 4 ]     // [ 1 + 2i,  3 + 4i ]
-var b:[Float] = [ 1, -2, -3, 4 ]     // [ 1 - 2i, -3 + 4i ]
+var a:[Float] = [1,  2,  3, 4]     // [ 1 + 2i,  3 + 4i ]
+var b:[Float] = [1, -2, -3, 4]     // [ 1 - 2i, -3 + 4i ]
 var alpha: Float = 1
 
 //               alpha * a  +   b
 
-cblas_caxpy( 2, &alpha, &a, 1, &b, 1 )
+cblas_caxpy(2, &alpha, &a, 1, &b, 1)
 
 b                                    // [ 2 + 0i, 0 + 8 i ]
 /*:
@@ -37,18 +37,16 @@ struct Complex: CustomStringConvertible {
 		
 		if fabsf(real) > threshold && fabsf(imag) > threshold {
 			return "\(real) + \(imag) i"
-		}
-		else if fabsf(imag) > threshold {
+		} else if fabsf(imag) > threshold {
 			return "\(imag) i"
-		}
-		else {
+		} else {
 			return "\(real) + 0 i"
 		}
 	}
 }
 
-var c: [Complex] = [ Complex(real: 1, imag: 2), Complex(real: 3, imag: 4) ]
-var d: [Complex] = [ Complex(real: 1, imag:-2), Complex(real:-3, imag: 4) ]
+var c: [Complex] = [Complex(real: 1, imag: 2), Complex(real: 3, imag: 4)]
+var d: [Complex] = [Complex(real: 1, imag:-2), Complex(real:-3, imag: 4)]
 
 //               alpha * c  +   d
 
@@ -60,23 +58,23 @@ d[1]
 ## Variation Using a Postfix Operator
 - Note: The above struct makes the code very wordy. One can clean up the code by actually making something like the "i" above into an operator. Here, instead of using the letter (which you can't turn into an operator anyway), we make use of the **¡** (an inverted exclamation mark, easily typed using option-1). This makes the code look very much like standard math notation.
 */
-postfix operator ¡ {}
+postfix operator ¡
 postfix func ¡ (x: Float) -> Complex {
 	return Complex(real: 0, imag: x)
 }
-infix operator + {}
-func + (lhs: Float, rhs: Complex) -> Complex {
-	return Complex(real: lhs + rhs.real, imag:rhs.imag)
+infix operator +
+func + (left: Float, right: Complex) -> Complex {
+	return Complex(real: left + right.real, imag: right.imag)
 }
-infix operator - {}
-func - (lhs: Float, rhs: Complex) -> Complex {
-	return Complex(real: lhs - rhs.real, imag:-1 * rhs.imag)
+infix operator -
+func - (left: Float, right: Complex) -> Complex {
+	return Complex(real: left - right.real, imag: -1 * right.imag)
 }
 
-var e: [Complex] = [ 1 + 2¡,  3 + 4¡ ]
-var f: [Complex] = [ 1 - 2¡, -3 + 4¡ ]
+var e: [Complex] = [1 + 2¡,  3 + 4¡]
+var f: [Complex] = [1 - 2¡, -3 + 4¡]
 
-cblas_caxpy( 2, &alpha, &e, 1, &f, 1 )
+cblas_caxpy(2, &alpha, &e, 1, &f, 1)
 
 f[0]
 f[1]
@@ -84,8 +82,8 @@ f[1]
 ## Dot product of complex vectors:
 - Note: Type-completion hint as of Xcode 7.3, since it now does fuzzy string completion: To find the BLAS dot product function without wading thru the documentation, start by typing "blas" then type "dot" and right away you're down to a selection of 4 versions of the dot product. Season to taste from there.
 */
-var g: [Complex] = [ 1 + 2¡,  3 + 4¡ ]
-var h: [Complex] = [ 1 - 2¡, -3 + 4¡ ]
+var g: [Complex] = [1 + 2¡,  3 + 4¡]
+var h: [Complex] = [1 - 2¡, -3 + 4¡]
 
 var gDotH: Complex = 0¡
 

--- a/ComplexBLAS.playground/contents.xcplayground
+++ b/ComplexBLAS.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='osx' display-mode='rendered' executeOnSourceChanges='false'>
+<playground version='5.0' target-platform='osx' display-mode='rendered'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/ComplexBLAS.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ComplexBLAS.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Compression.playground/Contents.swift
+++ b/Compression.playground/Contents.swift
@@ -15,15 +15,15 @@ high speed + energy efficiency
 
 All optimzed on Apple hardware, so better than just using usual zlib
 */
-let source:[UInt8] = [1,4,9,8,6,3,0,2,9,2]
+let source:[UInt8] = [1, 4, 9, 8, 6, 3, 0, 2, 9, 2]
 let destinationCapacity = size_t(30)
-var destination = [UInt8](count: Int(destinationCapacity), repeatedValue:0)
+var destination = [UInt8](unsafeUninitializedCapacity: Int(destinationCapacity), initializingWith: {_, _ in})
 
 let destinationSize = compression_encode_buffer(&destination, destinationCapacity, source, source.count, nil, COMPRESSION_LZFSE)
 
 destination
 
-var returnBuffer = [UInt8](count: source.count, repeatedValue:0)
+var returnBuffer = [UInt8](unsafeUninitializedCapacity: source.count, initializingWith: {_, _ in})
 
 compression_decode_buffer(&returnBuffer, source.count, destination, destinationSize, nil, COMPRESSION_LZFSE)
 

--- a/Compression.playground/contents.xcplayground
+++ b/Compression.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='osx' display-mode='rendered' executeOnSourceChanges='false'>
+<playground version='5.0' target-platform='osx' display-mode='rendered'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/Compression.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Compression.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Distances.playground/contents.swift
+++ b/Distances.playground/contents.swift
@@ -6,21 +6,21 @@ import Cocoa
 import Accelerate
 
 var points:[CGPoint] = [
-	CGPointMake( -40,   0),
-	CGPointMake(  35,  40),
-	CGPointMake(  30,  70),
-	CGPointMake( 110,  20),
-	CGPointMake(  10, -10),
-	CGPointMake( -20, -70),
-	CGPointMake(-110, -20),
-	CGPointMake(  20, -40),
-	CGPointMake(   0,   0)
+    CGPoint(x:  -40, y:   0),
+    CGPoint(x:   35, y:  40),
+    CGPoint(x:   30, y:  70),
+    CGPoint(x:  110, y:  20),
+    CGPoint(x:   10, y: -10),
+    CGPoint(x:  -20, y: -70),
+    CGPoint(x: -110, y: -20),
+    CGPoint(x:   20, y: -40),
+    CGPoint(x:    0, y:   0)
 ]
 
 let path = NSBezierPath()
-path.moveToPoint(points[0])
+path.move(to: points[0])
 for i in 1..<points.count {
-	path.lineToPoint(points[i])
+    path.line(to: points[i])
 }
 //:## Let's say you have a set of points describing a path:
 path
@@ -28,14 +28,14 @@ path
 ## How far are we from the origin at each step?
 - Note: Put away that geometry book! (Actually, no, go ahead, geometry is great, just not needed here.) We have a distance function in the vDSP library! A few lines of set-up code and then a one-liner, and we get each leg's distance as an array.
 */
-var xs = points.flatMap { Float($0.x) }
-var ys = points.flatMap { Float($0.y) }
+var xs = points.compactMap { Float($0.x) }
+var ys = points.compactMap { Float($0.y) }
 
-var distance = [Float](count: points.count, repeatedValue:0)
+var distance = [Float](unsafeUninitializedCapacity: points.count, initializingWith: {_, _ in})
 
 vDSP_vdist(&xs, 1, &ys, 1, &distance, 1, vDSP_Length(points.count))
 
 distance.map { $0 }
 //:## Total distance
-distance.reduce(0, combine: +)
+distance.reduce(0, +)
 

--- a/Distances.playground/contents.xcplayground
+++ b/Distances.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='osx' display-mode='raw' executeOnSourceChanges='false'>
+<playground version='5.0' target-platform='osx' display-mode='raw'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/Distances.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Distances.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/LAPACK.playground/contents.swift
+++ b/LAPACK.playground/contents.swift
@@ -34,7 +34,7 @@ var elementsInB:      LAInt = 3
 var bSolutionCount:   LAInt = 1
 
 var outputOk: LAInt = 0
-var pivot = [LAInt](count: equations, repeatedValue: 0)
+var pivot = [LAInt](unsafeUninitializedCapacity: equations, initializingWith: {_, _ in})
 
 sgesv_( &numberOfEquations, &bSolutionCount, &A, &columnsInA, &pivot, &b, &elementsInB, &outputOk)
 

--- a/LAPACK.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/LAPACK.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/LinearAlgebra.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/LinearAlgebra.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Schrödinger.playground/contents.swift
+++ b/Schrödinger.playground/contents.swift
@@ -10,11 +10,11 @@ let N = 80
 let dx = 10 / Double(N)
 let dx² = dx * dx
 
-var hDiag = [Double](count:  N, repeatedValue: 0)
-var hOff  = [Double](count:  N, repeatedValue:-1)
-var v     = [Double](count:  N, repeatedValue: 0)
-var work  = [Double](count:2*N, repeatedValue: 0)
-var z     = [Double](count:N*N, repeatedValue: 0)
+var hDiag = Array<Double>(repeating:  0, count: N)
+var hOff  = Array<Double>(repeating: -1, count: N)
+var v     = Array<Double>(repeating:  0, count: N)
+var work  = Array<Double>(repeating:  0, count: 2 * N)
+var z     = Array<Double>(repeating:  0, count: N * N)
 
 var n:      LAInt = LAInt(N-1)
 var ldz:    LAInt = n

--- a/Schrödinger.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Schrödinger.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SparseBLAS.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SparseBLAS.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/simd.playground/Contents.swift
+++ b/simd.playground/Contents.swift
@@ -17,17 +17,17 @@ import simd
 ### Convenient and frequently useful data types
 - Note: The component labels are optional
 */
-let geoLocation = float2(x: 15.1231, y: -23.846)
+let geoLocation = SIMD2<Float>(x: 15.1231, y: -23.846)
 
-let voxelLocation = float3(3, -2, 4)
+let voxelLocation = SIMD3<Float>(3, -2, 4)
 
-let spacetimeLocation = float4(x: 2, y: 5, z: 3, w: -1)
+let spacetimeLocation = SIMD4<Float>(x: 2, y: 5, z: 3, w: -1)
 
 let specialRelativitySpacetimeMetric = float4x4([
-	[ 1, 0, 0, 0],
-	[ 0, 1, 0, 0],
-	[ 0, 0, 1, 0],
-	[ 0, 0, 0,-1]
+	[1, 0, 0, 0],
+	[0, 1, 0, 0],
+	[0, 0, 1, 0],
+	[0, 0, 0,-1]
 ])
 
 spacetimeLocation * specialRelativitySpacetimeMetric * spacetimeLocation
@@ -47,8 +47,8 @@ spacetimeLocation.w
 ----
 ### Easier ways to do common functions without needing to roll your own:
 */
-let x = double3(2)        // one argument makes all components to the value
-let y = double3(5, 6, 7)
+let x = SIMD3<Double>(repeating: 2)        // one argument makes all components to the value
+let y = SIMD3<Double>(5, 6, 7)
 
 x + 3 * y
 
@@ -63,26 +63,30 @@ reflect(x, n: y)   // reflect the vector x in the plane defined by the normal ve
 Lots of standard functions available.
 - Note: Matrices are (columns) x (rows). This is the opposite of most math / science books, but some graphics programming texts use this ordering and it leaked into some (but by no means all) real world code. Why they decided to go down this path is a historical accident we are stuck with. This means the order of operations may be the opposite of what you expect or read in a source text. Re-ordering and transposing can get things right.
 */
-let m = float3x2( [[1,2], [3,4], [5,6]] ) // collection of *columns*
+let m = float3x2([ // collection of *columns*
+    [1, 2],
+    [3, 4],
+    [5, 6]
+])
 
-m.cmatrix
+m
 m.transpose
 
 geoLocation * m
 m.transpose * geoLocation
 
 abs(geoLocation)
-vector_max(voxelLocation, float3(-5))
-vector_max(vector_abs(voxelLocation), vector_abs(float3(-5)))
-vector_clamp(voxelLocation, float3(-1), float3(2))
+max(voxelLocation, SIMD3<Float>(repeating: -5))
+max(abs(voxelLocation), abs(SIMD3<Float>(repeating: -5)))
+clamp(voxelLocation, min: SIMD3<Float>(repeating: -1), max: SIMD3<Float>(repeating: 2))
 
-vector_smoothstep(float3(-10), float3(10), voxelLocation)
+smoothstep(SIMD3<Float>(repeating: -10), edge0: SIMD3<Float>(repeating: 10), edge1: voxelLocation)
 //: - Note: There are fats and precise versions of several functions. Make sure to actually check on the precision that you need in your apps and then make a choice about which functions to use.
-vector_fast_recip(geoLocation)
-vector_precise_recip(geoLocation)
+simd_fast_recip(geoLocation)
+simd_precise_recip(geoLocation)
 
-vector_fast_recip(geoLocation) * geoLocation
-vector_precise_recip(geoLocation) * geoLocation
+simd_fast_recip(geoLocation) * geoLocation
+simd_precise_recip(geoLocation) * geoLocation
 /*:
 ----
 - Note: There may be times when you need to interoperate with other parts of the system that insist on, say, a vector_float4 instead of a float4, or a matrix_float4x4 instaed of float4x4. Just convert to the other type and be happy.

--- a/simd.playground/contents.xcplayground
+++ b/simd.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='osx' display-mode='rendered' executeOnSourceChanges='false'>
+<playground version='5.0' target-platform='osx' display-mode='rendered'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/simd.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/simd.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/vBigNum.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/vBigNum.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/vDSP.playground/contents.swift
+++ b/vDSP.playground/contents.swift
@@ -15,7 +15,7 @@ var count: vDSP_Length
 count = 10
 var start: Float = -3
 var increment: Float =  0.1
-var ramp = [Float](count:Int(count), repeatedValue:0)
+var ramp = [Float](unsafeUninitializedCapacity:Int(count), initializingWith: {_, _ in})
 
 vDSP_vramp( &start, &increment, &ramp, 1, count )
 
@@ -29,7 +29,7 @@ data = [0,0,0,0,9,-4,7,10,6,-8,9,-14,3,-4,-6,-8,8,7,4,2,0,0,0,0]
 data.map { $0 }
 
 count = vDSP_Length(data.count)
-output = [Float](count:Int(count), repeatedValue:0)
+output = [Float](unsafeUninitializedCapacity:Int(count), initializingWith: {_, _ in})
 
 vDSP_vabs( &data, 1, &output, 1, count )
 

--- a/vDSP.playground/contents.xcplayground
+++ b/vDSP.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='osx' display-mode='rendered' executeOnSourceChanges='false'>
+<playground version='5.0' target-platform='osx' display-mode='rendered'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/vDSP.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/vDSP.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/vForce.playground/Contents.swift
+++ b/vForce.playground/Contents.swift
@@ -4,8 +4,8 @@ _Jeff Biggus (@hyperjeff) March, 2016_
 */
 import Accelerate
 
-func floats(n: Int32)->[Float] {
-	return [Float](count:Int(n), repeatedValue:0)
+func floats(n: Int32) -> [Float] {
+    return [Float](unsafeUninitializedCapacity: Int(n), initializingWith: {_, _ in})
 }
 /*:
 ## Example: Absolute values
@@ -13,10 +13,10 @@ func floats(n: Int32)->[Float] {
 - Note: "count" needs to be Int32, not just Int
 */
 var count: Int32 = 4
-var a:[Float] = [3,-2,5,-10]
-var aAbsolute = floats(count)
+var a: [Float] = [3, -2, 5, -10]
+var aAbsolute = floats(n: count)
 
-vvfabsf( &aAbsolute, &a, &count )
+vvfabsf(&aAbsolute, &a, &count)
 
 aAbsolute
 /*:
@@ -24,50 +24,50 @@ aAbsolute
 - Note: Sometimes NO variables in the docs at all!
 */
 count = 3
-var b:[Float] = [3.3796, 1.8036, -2.1205]
-var bInt = floats(count)
+var b: [Float] = [3.3796, 1.8036, -2.1205]
+var bInt = floats(n: count)
 
-vvintf( &bInt, &b, &count )
+vvintf(&bInt, &b, &count)
 
 bInt
 //:## Example: Square Roots
 count = 4
-var c:[Float] = [16,9,4,1]
-var cSquareRoots = floats(count)
+var c:[Float] = [16, 9, 4, 1]
+var cSquareRoots = floats(n: count)
 
-vvsqrtf( &cSquareRoots, &c, &count )
+vvsqrtf(&cSquareRoots, &c, &count)
 
 cSquareRoots
 //:## Example: Flipping Numbers Over
 count = 4
 var d:[Float] = [1/3, 2/5, 1/8, -3/1]
-var dFlipped = floats(count)
+var dFlipped = floats(n: count)
 
-vvrecf( &dFlipped, &d, &count )
+vvrecf(&dFlipped, &d, &count)
 
 dFlipped
 //:## Example: Taking a Sine
 let π: Float = 355/113
 count = 100
-var ramp = floats(count)
+var ramp = floats(n: count)
 var rampStart: Float = 0
-var rampIncrease: Float = 1/(5 * π) //Float(count) / (2 * π)
+var rampIncrease: Float = 1 / (5 * π) // Float(count) / (2 * π)
 
-var rampSin = floats(count)
+var rampSin = floats(n: count)
 
-vDSP_vramp( &rampStart, &rampIncrease, &ramp, 1, vDSP_Length(count) )
+vDSP_vramp(&rampStart, &rampIncrease, &ramp, 1, vDSP_Length(count))
 ramp
 
-vvsinpif( &rampSin, &ramp, &count )
+vvsinpif(&rampSin, &ramp, &count)
 
 rampSin.map { $0 }
 //:## Act _now_ and we'll throw in this _Cosine_ for free!
-var rampCos = floats(count)
-rampIncrease = 1/5
-vDSP_vramp( &rampStart, &rampIncrease, &ramp, 1, vDSP_Length(count) )
+var rampCos = floats(n: count)
+rampIncrease = 1 / 5
+vDSP_vramp(&rampStart, &rampIncrease, &ramp, 1, vDSP_Length(count))
 ramp
 
-vvsincosf( &rampSin, &rampCos, &ramp, &count )
+vvsincosf(&rampSin, &rampCos, &ramp, &count)
 
 rampSin.map { $0 }
 

--- a/vForce.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/vForce.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/vImage.playground/Contents.swift
+++ b/vImage.playground/Contents.swift
@@ -3,16 +3,16 @@ import CoreImage
 import Accelerate
 import XCPlayground
 
-let cookiesURL = NSURL(fileURLWithPath: NSBundle.mainBundle().pathForImageResource("boobie.png")!)
+let cookiesURL = NSURL(fileURLWithPath: Bundle.main.pathForImageResource("boobie.png")!)
 let imageSource = CGImageSourceCreateWithURL(cookiesURL, nil)
 let image = CGImageSourceCreateImageAtIndex(imageSource!, 0, nil)!
 
-let width = CGImageGetWidth(image)
-let height = CGImageGetHeight(image)
-let bytesPerRow = CGImageGetBytesPerRow(image)
+let width = image.width
+let height = image.height
+let bytesPerRow = image.bytesPerRow
 let size = NSMakeSize(CGFloat(width), CGFloat(height))
 
-let nsImage = NSImage(CGImage: image, size: size)
+let nsImage = NSImage(cgImage: image, size: size)
 var frame = NSMakeRect(0, 0, 0, 0)
 frame.size = size
 let playgroundView = NSImageView(frame: frame)
@@ -23,9 +23,9 @@ var backgroundColor : Array<UInt8> = [0,0,0,0]
 let fillBackground: vImage_Flags = UInt32(kvImageBackgroundColorFill)
 
 func doStuff() {
-	let inProvider = CGImageGetDataProvider(image)
-	let providerCopy = CGDataProviderCopyData(inProvider)
-	let inBitmapData = UnsafeMutablePointer<UInt8>(CFDataGetBytePtr(providerCopy))
+    guard let inProvider = image.dataProvider else { return }
+    let providerCopy = inProvider.data
+    let inBitmapData = UnsafeMutableRawPointer(mutating: CFDataGetBytePtr(providerCopy))
 	
 	var inBuffer = vImage_Buffer(data: inBitmapData, height: UInt(height), width: UInt(width), rowBytes: bytesPerRow)
 	
@@ -48,23 +48,24 @@ func doStuff() {
 	
 	vImageHorizontalReflect_ARGB8888(&inBuffer, &outBuffer, fillBackground)
 	
-	let context = CGBitmapContextCreate(outBuffer.data, width, height, 8, outBuffer.rowBytes, colorSpace, CGImageAlphaInfo.NoneSkipLast.rawValue)
+    guard let context = CGContext(data: outBuffer.data, width: width, height: height, bitsPerComponent: 8, bytesPerRow: outBuffer.rowBytes, space: colorSpace, bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue) else { return }
 	
-	let outCGimage = CGBitmapContextCreateImage(context)
+    let outCGimage = context.makeImage()
 	
-	playgroundView.image = NSImage(CGImage: outCGimage!, size: size)
+    playgroundView.image = NSImage(cgImage: outCGimage!, size: size)
 	
 	free(pixelBuffer)
 }
 
 class Controller: NSViewController {
-	override func mouseDown(event: NSEvent) {
-		doStuff()
-	}
-	
-	override func mouseUp(event: NSEvent) {
-		playgroundView.image = nsImage
-	}
+    
+    override func mouseDown(with event: NSEvent) {
+        doStuff()
+    }
+    
+    override func mouseUp(with event: NSEvent) {
+        playgroundView.image = nsImage
+    }
 }
 
 let controller = Controller()

--- a/vImage.playground/contents.xcplayground
+++ b/vImage.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='osx' display-mode='raw' executeOnSourceChanges='false'>
+<playground version='5.0' target-platform='osx' display-mode='raw'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/vImage.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/vImage.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
I have updated the playgrounds to Swift 5.1 and Xcode 11. Note that *all playgrounds now work correctly except two* which I wasn't able to update, unfortunately. These are FFT and SmoothWalker. 

Please accept the pull request. 🙂